### PR TITLE
`setup.sh` Support for Debian-based Prediction Backend Deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Here I've chosen to focus on one, and only one, cryptocurrency at the moment: Bi
 ### Setup
 
 **Note: for the moment I've targeted Ubuntu 20.04/22.04 for automated setup.**
-Will **_probabaly_** still work on other Debian flavored Linux distros, but YMMV.
+Will **_probably_** still work on other Debian flavored Linux distros, but YMMV.
 
 1. You can clone this repository onto a machine with:
 
@@ -149,7 +149,7 @@ This will build the frontend client into the `frontend/.next` directory. To serv
 npm run start
 ```
 
-A great candidate for deployment is like [Vercel](https://vercel.com), just make sure you set the `frontend` directory as the project directory after linking your repo. Other cloud providers will work as long as then call `npm run build` and `npm run start` in the root of the `frontend` directory.
+A great candidate for deployment is [Vercel](https://vercel.com), just make sure you set the `frontend` directory as the project directory after linking your repo. Other cloud providers will work as long as then call `npm run build` and `npm run start` in the root of the `frontend` directory.
 
 ### More to come (see below)
 

--- a/setup.sh
+++ b/setup.sh
@@ -1,10 +1,11 @@
 #! /bin/bash
 # This script sets up a local development environment on an Ubuntu 20.04/22.04 machine
-# to work with Poetry managed Python3.10 projects. 
+# to work with Poetry managed Python3.10 projects.
 # 
 # Targets:
 #   - Poetry 1.5.1
 #   - Python3.10
+#   - Docker 24.0.6
 #
 # Requirements:
 #   - Ubuntu 20.04/22.04

--- a/setup.sh
+++ b/setup.sh
@@ -67,6 +67,7 @@ then
   echo "Poetry is already in PATH 🟢"
 else
   echo -e "# Add Poetry (Python Package Manager) to PATH\nexport PATH="/home/$USER/.local/bin:$PATH"" >> ~/.bashrc
+  source ~/.bashrc
 fi
 
 # Configure Poetry to put build all virtual environments in the project's directory
@@ -136,6 +137,8 @@ fi
 # you need to set up the Docker repository. Afterward, you can install and update Docker from the repository.
 # -----------------------------------------------------------------------------------------------------------
 
+DISTRO=$(lsb_release -d | awk -F ' ' '{print tolower($2)}')
+
 # Add Docker’s official GPG key
 if [ -f /etc/apt/keyrings/docker.gpg ]
 then
@@ -151,7 +154,7 @@ else
   sudo install -m 0755 -d /etc/apt/keyrings
   
   # Download the GPG key from Docker
-  curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+  curl -fsSL https://download.docker.com/linux/$DISTRO/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
   sudo chmod a+r /etc/apt/keyrings/docker.gpg
 fi
 
@@ -162,7 +165,7 @@ then
 else
   echo 'Installing docker.list repository at /etc/apt/sources.list.d/docker.list 🔧'
   echo \
-    "deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
+    "deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/$DISTRO \
     "$(. /etc/os-release && echo "$VERSION_CODENAME")" stable" | \
     sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
 fi


### PR DESCRIPTION
# Debian Prediction Backend Deploy Target (Raspberry Pi)

1. Added `source ~/.bashrc` after injection of Poetry into PATH

2. Generalized Docker installation to support at minimum both Ubuntu and Debian distros. 

## Clean Debian Installation of Backend

An installation of the prediction backend onto a Debian server should run idempotently. 
