### PR TITLE
Image Timezone Configuration and UTC Fields in PredictionResult

### DIFF
--- a/deploy/prediction-docker-compose.yml
+++ b/deploy/prediction-docker-compose.yml
@@ -4,6 +4,8 @@ services:
     restart: always
     ports:
       - 8000:8000
+    volumes:
+      - /etc/localtime:/etc/localtime:ro
 
 # docker compose -f deploy/prediction-docker-compose.yml up --detach --pull predict
 # docker compose -f deploy/prediction-docker-compose.yml down predict 


### PR DESCRIPTION
## Time Configurations

1. `prediction-docker-compose.yml`: added binding for localtime on server
    - the images inherit timezoning and localtime from the server that they are built on.
    - This does not affect predictions because they are computed with UTC timestamps - this change is purely a UI configuration.

2. `server.py`: converted time fields in `PredictionResult` to UTC for consistency in frontend parsing.