### PR TITLE
Add Parity for Deploy Setup Scripts (Debian + Ubuntu)

### DIFF
--- a/deploy/setup_deploy_deb.sh
+++ b/deploy/setup_deploy_deb.sh
@@ -177,7 +177,7 @@ then
 else
   echo "Building webhook 🦫"
   pushd crypto-real-time-inference/deploy
-  go build
+  go build webhook.go
   popd
 fi
 


### PR DESCRIPTION
Both  `setup_deploy_deb.sh` and `setup_deploy_ub.sh` prepare the server to run our container and webhook with Docker and Go.