### PR TITLE
Rpi Deploy Testing Updates

### DIFF
--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -8,10 +8,10 @@
 # Note that each script called is idempotent.
 
 # Setup the deployment environment
-bash deploy/setup_deploy_deb.sh
+bash deploy/setup_deploy_ub.sh
 
 # Set environment variables for deploy
-source ./deploy/environment.sh
+source deploy/environment.sh
 
 # Spin up the Prediction server
 bash deploy/deploy_container.sh

--- a/deploy/deploy_container.sh
+++ b/deploy/deploy_container.sh
@@ -3,4 +3,4 @@
 # Spin up the Prediction server if the container is not running; OR if the image on disk 
 # isn't up to date, pull the new image, tear down the running container, and spin up the
 # new container
-docker compose -f deploy/prediction-docker-compose.yml up --detach --pull predict
+sudo docker compose -f deploy/prediction-docker-compose.yml up --detach --pull predict

--- a/deploy/setup_cloudflared.sh
+++ b/deploy/setup_cloudflared.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #-----------------------------------------------------------------------------------------------------------#
-# This script sets up a deployment environment on an Ubuntu 20.04/22.04
+# This script sets up a tunneling dependencies on an Ubuntu 20.04/22.04
 #
 # Documentation:
 # https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/get-started/create-local-tunnel/
@@ -12,13 +12,13 @@ if ( which cloudflared > /dev/null )
 then
   echo "cloudflared installed 🟢"
 else
-# Add Cloudflare’s package signing key
-sudo mkdir -p --mode=0755 /usr/share/keyrings
-curl -fsSL https://pkg.cloudflare.com/cloudflare-main.gpg | sudo tee /usr/share/keyrings/cloudflare-main.gpg >/dev/null
+  # Add Cloudflare’s package signing key
+  sudo mkdir -p --mode=0755 /usr/share/keyrings
+  curl -fsSL https://pkg.cloudflare.com/cloudflare-main.gpg | sudo tee /usr/share/keyrings/cloudflare-main.gpg >/dev/null
 
-# Add Cloudflare’s apt repo to your apt repositories
-echo "deb [signed-by=/usr/share/keyrings/cloudflare-main.gpg] https://pkg.cloudflare.com/cloudflared $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/cloudflared.list
+  # Add Cloudflare’s apt repo to your apt repositories
+  echo "deb [signed-by=/usr/share/keyrings/cloudflare-main.gpg] https://pkg.cloudflare.com/cloudflared $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/cloudflared.list
 
-# Update repositories and install cloudflared
-sudo apt-get update && sudo apt-get install cloudflared
+  # Update repositories and install cloudflared
+  sudo apt-get update && sudo apt-get install cloudflared
 fi

--- a/deploy/setup_cloudflared.sh
+++ b/deploy/setup_cloudflared.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #-----------------------------------------------------------------------------------------------------------#
-# This script sets up a tunneling dependencies on an Ubuntu 20.04/22.04
+# This script sets up tunneling dependencies on an Ubuntu 20.04/22.04
 #
 # Documentation:
 # https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/get-started/create-local-tunnel/

--- a/deploy/setup_deploy_deb.sh
+++ b/deploy/setup_deploy_deb.sh
@@ -41,7 +41,7 @@ fi
 # Ensure wget is installed on the machine
 if ( which wget > /dev/null )
 then
-  echo "curl is already installed 🟢"
+  echo "wget is already installed 🟢"
 else
   echo "Installing wget 🌀"
   sudo apt install -y wget

--- a/deploy/setup_deploy_deb.sh
+++ b/deploy/setup_deploy_deb.sh
@@ -30,6 +30,23 @@ else
   sudo apt install -y curl
 fi
 
+# Check if wget is in the apt-cache
+if ( apt-cache show wget > /dev/null )
+then
+  echo "wget is already cached 🟢"
+else
+  sudo apt update
+fi
+
+# Ensure wget is installed on the machine
+if ( which wget > /dev/null )
+then
+  echo "curl is already installed 🟢"
+else
+  echo "Installing wget 🌀"
+  sudo apt install -y wget
+fi
+
 # Check if make is in the apt-cache
 if ( apt-cache show make > /dev/null )
 then
@@ -137,12 +154,12 @@ fi
 # 3) Go Install: here we'll install and configure Go
 # -----------------------------------------------------------------------------------------------------------
 
-# Check if Go is in the apt-cache
-if ( apt-cache show go > /dev/null )
+# Pull the machine's chip architecture
+if [ "$(uname -m)" == "x86_64" ]
 then
-  echo "Go is already cached 🟢"
+  CHIP_ARCH="amd64"
 else
-  sudo apt update
+  CHIP_ARCH="arm64"
 fi
 
 # Install Go
@@ -151,10 +168,10 @@ then
   echo "Go is already installed 🟢"
 else
   echo "Installing Go 🦫"
-  curl -O https://go.dev/dl/go.1.21.2.src.tar.gz
-  sudo tar -C /usr/local -xzf go1.21.2.src.tar.gz
+  wget -O https://go.dev/dl/go1.21.3.linux-$CHIP_ARCH.tar.gz
+  sudo tar -C /usr/local -xzf go1.21.3.linux-$CHIP_ARCH.tar.gz
   echo -e "# Add Go to PATH\nexport PATH="/usr/local/go/bin:$PATH"" >> ~/.profile
-  exec bash
+  source ~/.profile
 fi
 
 # Verify installation of Go
@@ -171,12 +188,12 @@ fi
 # -----------------------------------------------------------------------------------------------------------
 
 # Build the webhook server if it does not exist
-if ( -f deploy/webhook )
+if [ -f deploy/webhook ]
 then
   echo "webhook already built 🟢"
 else
   echo "Building webhook 🦫"
-  pushd crypto-real-time-inference/deploy
+  pushd deploy
   go build webhook.go
   popd
 fi

--- a/deploy/setup_deploy_ub.sh
+++ b/deploy/setup_deploy_ub.sh
@@ -48,6 +48,23 @@ else
   sudo apt install -y curl
 fi
 
+# Check if wget is in the apt-cache
+if ( apt-cache show wget > /dev/null )
+then
+  echo "wget is already cached 🟢"
+else
+  sudo apt update
+fi
+
+# Ensure wget is installed on the machine
+if ( which wget > /dev/null )
+then
+  echo "curl is already installed 🟢"
+else
+  echo "Installing wget 🌀"
+  sudo apt install -y wget
+fi
+
 # Check if make is in the apt-cache
 if ( apt-cache show make > /dev/null )
 then
@@ -155,12 +172,12 @@ fi
 # 3) Go Install: here we'll install and configure Go
 # -----------------------------------------------------------------------------------------------------------
 
-# Check if Go is in the apt-cache
-if ( apt-cache show go > /dev/null )
+# Pull the machine's chip architecture
+if [ "$(uname -m)" == "x86_64" ]
 then
-  echo "Go is already cached 🟢"
+  CHIP_ARCH="amd64"
 else
-  sudo apt update
+  CHIP_ARCH="arm64"
 fi
 
 # Install Go
@@ -169,10 +186,10 @@ then
   echo "Go is already installed 🟢"
 else
   echo "Installing Go 🦫"
-  curl -O https://go.dev/dl/go.1.21.2.src.tar.gz
-  sudo tar -C /usr/local -xzf go1.21.2.src.tar.gz
+  wget -O https://go.dev/dl/go1.21.3.linux-$CHIP_ARCH.tar.gz
+  sudo tar -C /usr/local -xzf go1.21.3.linux-$CHIP_ARCH.tar.gz
   echo -e "# Add Go to PATH\nexport PATH="/usr/local/go/bin:$PATH"" >> ~/.profile
-  exec bash
+  source ~/.profile
 fi
 
 # Verify installation of Go
@@ -189,12 +206,12 @@ fi
 # -----------------------------------------------------------------------------------------------------------
 
 # Build the webhook server if it does not exist
-if ( -f deploy/webhook )
+if [ -f deploy/webhook ]
 then
   echo "webhook already built 🟢"
 else
   echo "Building webhook 🦫"
-  pushd crypto-real-time-inference/deploy
+  pushd deploy
   go build webhook.go
   popd
 fi

--- a/deploy/setup_deploy_ub.sh
+++ b/deploy/setup_deploy_ub.sh
@@ -59,7 +59,7 @@ fi
 # Ensure wget is installed on the machine
 if ( which wget > /dev/null )
 then
-  echo "curl is already installed 🟢"
+  echo "wget is already installed 🟢"
 else
   echo "Installing wget 🌀"
   sudo apt install -y wget


### PR DESCRIPTION
Swaps `wget` in place of `curl` for Go installation on server, injecting `$CHIP_ARCH` into Go installation URL.

Parity maintained between `setup_deploy_ub.sh` and `setup_deploy_deb.sh`.

## TODO

Logic to configure `webhook`, `Prediction Service`, and `tunnel` as services on server.