### PR TITLE
Add Callback Validation to Webhook Server

### DIFF
--- a/deploy/webhook.go
+++ b/deploy/webhook.go
@@ -1,38 +1,75 @@
-// Listens for POST requests and spins up a new container
+// Listens for POST requests and rolls an updated container
 package main
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"os"
 	"os/exec"
+
 	"github.com/gorilla/mux"
 )
 
+type Webhook struct {
+	CallbackURL string `json:"callback_url"`
+}
+
+type ValidationResponse struct {
+	State string `json:"state"`
+}
+
 func main() {
 	// Instantiate a request router
-	r := mux.NewRouter()
+	router := mux.NewRouter()
 
-	// Register the request handler on the request router object
-	r.HandleFunc("/infra/{deploy_key}", func(w http.ResponseWriter, r *http.Request) {
-		vars := mux.Vars(r)
-		deploy_key := vars["deploy_key"]
+	// Register the request handler on the request router
+	router.HandleFunc("/infra/{deploy_key}", func(writer http.ResponseWriter, request *http.Request) {
+		vars := mux.Vars(request)
+		deployKey := vars["deploy_key"]
 
-		if deploy_key == os.Getenv("DOCKER_HUB_DEPLOY_KEY") {
-			// Execute the bash script
-			fmt.Printf("\x1b[96mStarting container upgrade\x1b[0m 🐳\n\n")
-			out, err := exec.Command("deploy/deploy_container.sh").CombinedOutput()
+		if deployKey == os.Getenv("DOCKER_HUB_DEPLOY_KEY") {
+			// Parse the webhook body and extract the callback url
+			request.Body = http.MaxBytesReader(writer, request.Body, 1048576)
+			decoder := json.NewDecoder((request.Body))
+			var webhook Webhook
+			parsingError := decoder.Decode(&webhook)
 
-			if err != nil {
-				fmt.Printf("Error: %s", err.Error())
+			if parsingError != nil {
+				fmt.Printf("Error: %s", parsingError.Error())
 			}
-			// Std ouput on server
-			fmt.Printf("\x1b[96mThe output is:\x1b[0m\n%s\n", out)
+
+			// Construct the validation response
+			validationResponse := ValidationResponse{State: "success"}
+			jsonResponse, jsonError := json.Marshal(validationResponse)
+
+			if jsonError != nil {
+				fmt.Printf("Error: %s", jsonError.Error())
+			}
+
+			// Validate the webhook by posting to the callback url
+			_, responseError := http.NewRequest("POST", webhook.CallbackURL, bytes.NewBuffer(jsonResponse))
+			if responseError != nil {
+				fmt.Printf("Error: %s", responseError.Error())
+			}
+
+			fmt.Printf("\x1b[96mSuccessfully validated webhook\x1b[0m ✅\n")
+
+			// Execute the deployment
+			fmt.Printf("\x1b[96mStarting container upgrade\x1b[0m 🐳\n\n")
+			output, deployError := exec.Command("deploy/deploy_container.sh").CombinedOutput()
+
+			if deployError != nil {
+				fmt.Printf("Error: %s", deployError.Error())
+			}
+
+			fmt.Printf("\x1b[96mThe output is:\x1b[0m\n%s\n", output)
 			fmt.Printf("\x1b[96mFinished container upgrade\x1b[0m 🟢\n")
 		} else {
 			fmt.Printf("\x1b[96mInvalid deployment key\x1b[0m 🔴\n")
 		}
 	}).Methods("POST")
 
-	http.ListenAndServe("127.0.0.1:8001", r)
+	http.ListenAndServe("127.0.0.1:8001", router)
 }

--- a/src/server.py
+++ b/src/server.py
@@ -123,7 +123,6 @@ def get_prediction(
             * 1000
         )
     )
-    print(coinbase_candles_df["close"])
 
     # Construct the Prediction response
     response: PredictionResult = PredictionResult(


### PR DESCRIPTION
# Callback Validation Response

Adds logic that extracts the `callback_url` from the webhook json and sends a minimal `success` response back to the endpoint for validation - this provides feedback on Docker Hub for successful deployments.

Can be extended for more verbose logging. 