### PR TITLE
Webhook Router Migration from gorilla/mux to chi/v5. 

### DIFF
--- a/deploy/go.mod
+++ b/deploy/go.mod
@@ -2,4 +2,4 @@ module webhook
 
 go 1.21.1
 
-require github.com/gorilla/mux v1.8.0 // indirect
+require github.com/go-chi/chi/v5 v5.0.11

--- a/deploy/go.sum
+++ b/deploy/go.sum
@@ -1,2 +1,2 @@
-github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
-github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
+github.com/go-chi/chi/v5 v5.0.11 h1:BnpYbFZ3T3S1WMpD79r7R5ThWX40TaFB7L31Y8xqSwA=
+github.com/go-chi/chi/v5 v5.0.11/go.mod h1:DslCQbL2OYiznFReuXYUmQ2hGd1aDpCnlMNITLSKoi8=

--- a/deploy/webhook.go
+++ b/deploy/webhook.go
@@ -1,4 +1,4 @@
-// Listens for POST requests and rolls an updated container
+// Listens for POST requests and rolls out an updated container
 package main
 
 import (
@@ -9,7 +9,7 @@ import (
 	"os"
 	"os/exec"
 
-	"github.com/gorilla/mux"
+	"github.com/go-chi/chi/v5"
 )
 
 type Webhook struct {
@@ -22,54 +22,55 @@ type ValidationResponse struct {
 
 func main() {
 	// Instantiate a request router
-	router := mux.NewRouter()
+	router := chi.NewRouter()
 
 	// Register the request handler on the request router
-	router.HandleFunc("/infra/{deploy_key}", func(writer http.ResponseWriter, request *http.Request) {
-		vars := mux.Vars(request)
-		deployKey := vars["deploy_key"]
+	router.Post("/infra/{deploy_key}", func(writer http.ResponseWriter, request *http.Request) {
+		deployKey := chi.URLParam(request, "deploy_key")
 
-		if deployKey == os.Getenv("DOCKER_HUB_DEPLOY_KEY") {
-			// Parse the webhook body and extract the callback url
-			request.Body = http.MaxBytesReader(writer, request.Body, 1048576)
-			decoder := json.NewDecoder((request.Body))
-			var webhook Webhook
-			parsingError := decoder.Decode(&webhook)
-
-			if parsingError != nil {
-				fmt.Printf("Error: %s", parsingError.Error())
-			}
-
-			// Construct the validation response
-			validationResponse := ValidationResponse{State: "success"}
-			jsonResponse, jsonError := json.Marshal(validationResponse)
-
-			if jsonError != nil {
-				fmt.Printf("Error: %s", jsonError.Error())
-			}
-
-			// Validate the webhook by posting to the callback url
-			_, responseError := http.NewRequest("POST", webhook.CallbackURL, bytes.NewBuffer(jsonResponse))
-			if responseError != nil {
-				fmt.Printf("Error: %s", responseError.Error())
-			}
-
-			fmt.Printf("\x1b[96mSuccessfully validated webhook\x1b[0m ✅\n")
-
-			// Execute the deployment
-			fmt.Printf("\x1b[96mStarting container upgrade\x1b[0m 🐳\n\n")
-			output, deployError := exec.Command("deploy/deploy_container.sh").CombinedOutput()
-
-			if deployError != nil {
-				fmt.Printf("Error: %s", deployError.Error())
-			}
-
-			fmt.Printf("\x1b[96mThe output is:\x1b[0m\n%s\n", output)
-			fmt.Printf("\x1b[96mFinished container upgrade\x1b[0m 🟢\n")
-		} else {
+		if deployKey != os.Getenv("DOCKER_HUB_DEPLOY_KEY") {
 			fmt.Printf("\x1b[96mInvalid deployment key\x1b[0m 🔴\n")
+			return
 		}
-	}).Methods("POST")
+
+		// Parse the webhook body and extract the callback url
+		request.Body = http.MaxBytesReader(writer, request.Body, 1048576)
+		decoder := json.NewDecoder((request.Body))
+		var webhook Webhook
+		parsingError := decoder.Decode(&webhook)
+
+		if parsingError != nil {
+			fmt.Printf("Parsing Error: %s", parsingError.Error())
+		}
+
+		// Construct the validation response
+		validationResponse := ValidationResponse{State: "success"}
+		jsonResponse, jsonError := json.Marshal(validationResponse)
+
+		if jsonError != nil {
+			fmt.Printf("JSON Error: %s", jsonError.Error())
+		}
+
+		// Validate the webhook by posting to the callback url
+		_, responseError := http.NewRequest("POST", webhook.CallbackURL, bytes.NewBuffer(jsonResponse))
+		if responseError != nil {
+			fmt.Printf("Validation Response Error: %s", responseError.Error())
+		}
+
+		fmt.Printf("\x1b[96mSuccessfully validated webhook\x1b[0m ✅\n")
+
+		// Execute the deployment
+		fmt.Printf("\x1b[96mStarting container upgrade\x1b[0m 🐳\n\n")
+		output, deployError := exec.Command("deploy/deploy_container.sh").CombinedOutput()
+
+		if deployError != nil {
+			fmt.Printf("Deployment Error: %s", deployError.Error())
+		}
+
+		fmt.Printf("\x1b[96mThe output is:\x1b[0m\n%s\n", output)
+		fmt.Printf("\x1b[96mFinished container upgrade\x1b[0m 🟢\n")
+
+	})
 
 	http.ListenAndServe("127.0.0.1:8001", router)
 }


### PR DESCRIPTION
## Description

`chi` is a lighter weight dependency with higher performance, and it has more stable maintenance at the moment. 

There are no current security issues or breaking changes with `gorilla/mux` that I found, but for our purposes `chi` is a solid router. 

## Dependencies Added

- `github.com/go-chi/chi/v5`

## Dependencies Removed

- `github.com/gorilla/mux`

## Testing

Complete parity with previous `webhook.go` version.