### PR TITLE
Update Typing for Python3.9+

### DIFF
--- a/deploy/download_models_from_wandb.py
+++ b/deploy/download_models_from_wandb.py
@@ -1,4 +1,3 @@
-from typing import List, Dict
 import click
 import os
 import wandb
@@ -22,12 +21,12 @@ def download_model_from_wandb(product_id: str, model_name: str) -> None:
     model_url: str = f"{os.environ['WANDB_ENTITY']}/model-registry/"
     model_url += f"{product_id}_{model_name}_model:latest"
 
-    reg_model = wandb.use_artifact(
+    registry_model = wandb.use_artifact(
         model_url,
         type="model",
     )
     # Download the model to disk
-    model_path = reg_model.download(MODELS_DIR)
+    model_path = registry_model.download(MODELS_DIR)
     run.finish()
 
     logger.info(f"Successfully downloaded model to: {model_path} 🟢")
@@ -59,13 +58,13 @@ def download_latest_models_from_wandb(
     selection value ("all", "nn", or "ml") and downloads the latest model
     versions from W&B.
     """
-    COINS: Dict[str, List[str]] = {
+    COINS: dict[str, list[str]] = {
         "all": ["BTC-USD", "ETH-USD"],
         "bitcoin": ["BTC-USD"],
         "ethereum": ["ETH-USD"],
     }
 
-    MODELS: Dict[str, List[str]] = {
+    MODELS: dict[str, list[str]] = {
         "all": ["cnn", "lasso", "X_scaler"],
         "nn": ["cnn", "X_Scaler"],
         "ml": ["lasso", "X_scaler"],

--- a/src/data.py
+++ b/src/data.py
@@ -9,7 +9,7 @@ https://api.exchange.coinbase.com/products/{product_id}/
     candles?start={start_day}&end={end_day}&granularity=3600'
 """
 
-from typing import List, Dict
+from pathlib import Path
 from datetime import datetime, timedelta
 import time
 import requests
@@ -82,7 +82,7 @@ def download_ohlc_data_from_coinbase(
 
     # Construct a list of days as strings
     days: pd.DatetimeIndex = pd.date_range(start=from_day, end=to_day, freq="1D")
-    days: List[str] = [day.strftime("%Y-%m-%d") for day in days]
+    days: list[str] = [day.strftime("%Y-%m-%d") for day in days]
 
     # Create an empty DataFrame
     data: pd.DataFrame = pd.DataFrame()
@@ -90,9 +90,9 @@ def download_ohlc_data_from_coinbase(
     # START TIME
     start_time: float = time.time()
 
-    meta_data: Dict[str, tuple[int, int]] = {}
+    meta_data: dict[str, tuple[int, int]] = {}
 
-    product_ids: List[str] = product_ids.split()
+    product_ids: list[str] = product_ids.split()
 
     for product_id in product_ids:
         # Create a download dir for this currency if it doesn't exist
@@ -102,7 +102,7 @@ def download_ohlc_data_from_coinbase(
 
         for day in days:
             # Download the file if it doesn't exist
-            file_name = DATA_DIR / f"{product_id}_downloads" / f"{day}.parquet"
+            file_name: Path = DATA_DIR / f"{product_id}_downloads" / f"{day}.parquet"
             if file_name.exists():
                 logger.info(f"File {file_name} already exists, skipping")
                 data_one_day = pd.read_parquet(file_name)
@@ -152,10 +152,10 @@ def _download_data_for_one_day(product_id: str, day: str) -> pd.DataFrame:
     end: str = f"{end}T00:00:00"
 
     # Call the Coinbase Exchange REST API for this product, day, and granularity
-    URL: str = f"https://api.exchange.coinbase.com/products/{product_id}/"
-    URL += f"candles?start={start}&end={end}&granularity=3600"
-    r: requests.models.Response = requests.get(URL)
-    data: List[List[int, float, float, float, float, float]] = r.json()
+    url: str = f"https://api.exchange.coinbase.com/products/{product_id}/"
+    url += f"candles?start={start}&end={end}&granularity=3600"
+    r: requests.models.Response = requests.get(url)
+    data: list[list[int | float]] = r.json()
 
     # Transform list of lists to pandas dataframe and return
     return pd.DataFrame(

--- a/src/logger.py
+++ b/src/logger.py
@@ -1,14 +1,12 @@
 """
 Creates a console logger with formatting.
 """
-
-from typing import Optional
 import logging
 
 
-def get_console_logger(name: Optional[str] = "base") -> logging.Logger:
+def get_console_logger(name: str = "base") -> logging.Logger:
     # Create a logger if it doesn't exist
-    logger: logging.RootLogger = logging.getLogger(name)
+    logger: logging.Logger = logging.getLogger(name)
     if not logger.handlers:
         logger.setLevel(logging.DEBUG)
 

--- a/src/paths.py
+++ b/src/paths.py
@@ -11,11 +11,11 @@ DATA_DIR: Path = PARENT_DIR / "data"
 MODELS_DIR: Path = PARENT_DIR / "models"
 GRAPHS_DIR: Path = PARENT_DIR / "graphs"
 
-if not Path(DATA_DIR).exists():
+if not DATA_DIR.exists():
     os.mkdir(DATA_DIR)
 
-if not Path(MODELS_DIR).exists():
+if not MODELS_DIR.exists():
     os.mkdir(MODELS_DIR)
 
-if not Path(GRAPHS_DIR).exists():
+if not GRAPHS_DIR.exists():
     os.mkdir(GRAPHS_DIR)

--- a/src/server.py
+++ b/src/server.py
@@ -1,7 +1,7 @@
 """
 Backend server for inference service.
 """
-from typing import Dict, List
+
 from enum import Enum
 from pydantic import BaseModel
 from datetime import datetime, timedelta
@@ -32,7 +32,7 @@ class PredictionResult(BaseModel):
     difference: str
     time: str
     request_timestamp: str
-    past_24_hour_prices: List[float]
+    past_24_hour_prices: list[float]
 
 
 class Coin(str, Enum):
@@ -63,7 +63,7 @@ def get_prediction(
     coin: Coin = "BTC-USD",
     time_from: Time = "now",
     model_name: ModelName = "cnn",
-) -> Dict[str, PredictionResult]:
+) -> dict[str, PredictionResult]:
     """
     Takes a cryptocurrency product id, target hour and model name and
     returns that model's prediction for the cryptocurrency's price point the
@@ -87,7 +87,7 @@ def get_prediction(
     request_timestamp: str = str(int(initial_request_time.timestamp() * 1000))
 
     # Download current candle and past 25 hours for target time
-    coinbase_candles: List[List[int | float]] = download_data_for_t_hours(
+    coinbase_candles: list[list[int | float]] = download_data_for_t_hours(
         product_id=coin,
         date_time_hour=prediction_time,
         t=26,


### PR DESCRIPTION
## Type Hinting for Python3.9+

Python3.9+ supports type hints for standard collections using their constructors. This cleans up some of the imports across scripts.

## Seaborn and Matplotlib

I've chosen not to explicitly type `matplotlib` objects. Seaborn returns `matplotlib.axes.Axes` objects from plotting functions like `sns.lineplot()`, and though I think typing would add clarity, it would add explicit imports that would essentially be useless. 

See https://github.com/matplotlib/matplotlib/issues/26812 for discussion.

## Pattern Matching for Model Names

Swapped logic for model name pattern matching for clarity. 