### PR TITLE
Add .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,78 @@
+# Project
+frontend/
+graphs/
+deploy/
+set_environment_variables.sh
+setup.sh
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+# Usually these files are written by a python script from a template
+# before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Git
+**/.git
+**/.gitignore
+.github/
+
+# IDEs
+.vscode/
+
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+**/coverage
+.ruff_cache/
+
+# Virtual Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Docker
+Dockerfile
+docker-compose.yml
+.dockerignore
+
+# Documentation
+README.md
+LISCENCE
+

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@ __pycache__/
 *.py[cod]
 *$py.class
 
-# Environments
+# Virtual Environments
 .env
 .venv
 env/

--- a/Dockerfile
+++ b/Dockerfile
@@ -62,8 +62,6 @@ RUN poetry install --no-root
 COPY ./src/__init__.py ./src/feature_pipeline.py ./src/logger.py ./src/paths.py ./src/predict.py ./src/server.py src/
 COPY ./models models/
 
-WORKDIR /app/
-
 EXPOSE 8000
 
 CMD ["poetry", "run", "python", "-m", "uvicorn", "src.server:app", "--host", "0.0.0.0"]


### PR DESCRIPTION
## Description

When `docker build` is run the entire Docker context (the directory where `docker build` is run from) is sent to the Docker daemon before `COPY` commands are evaluated.

Defining artifacts to ignore decreases the build context sent to the Docker daemon - this can speed up local and particularly remote builds. 

It also gives you finer grained control over preventing security leaks. 
